### PR TITLE
use new title field for alt val in links

### DIFF
--- a/app/services/oregon_digital/solr_document_builder.rb
+++ b/app/services/oregon_digital/solr_document_builder.rb
@@ -25,7 +25,7 @@ module OregonDigital
     def out_doc_init
       { id: in_doc['id'],
         Spotlight::Engine.config.thumbnail_field => get_thumb,
-        #Spotlight::Engine.config.full_image_field => ENV['OD_URL'] + "/downloads/#{in_doc['id']}.jpg",
+        Spotlight::Engine.config.full_image_field => ENV['OD_URL'] + "/downloads/#{in_doc['id']}.jpg",
         oembed_url_ssm: "#{ENV['OD_URL']}/resource/#{in_doc['id']}",
         pid_ssm: in_doc['id'],
         spotlight_hidden_title_tesim: in_doc["desc_metadata__title_tesim"]

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
@@ -11,7 +11,7 @@
             <% if block_options[:thumbnail_image_url].present? %>
               <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:thumbnail_image_url], alt: document["spotlight_hidden_title_tesim"]), counter: -1) %></div>
             <% elsif ((block_options[:iiif_tilesource_base].present?) && (block_options[:iiif_tilesource_base] != "undefined"))  %>
-              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!400,400/0/default.jpg'), counter: -1) %></div>
+              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!400,400/0/default.jpg', alt: document["spotlight_hidden_title_tesim"]), counter: -1) %></div>
             <% elsif has_thumbnail? document %>
               <div class="thumbnail"><%= render_thumbnail_tag(document, {}, document_counter: -1) %></div>
             <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
@@ -9,7 +9,7 @@
         <div class="box" data-id="<%= document.id %>">
           <div class="contents">
             <% if block_options[:thumbnail_image_url].present? %>
-              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:thumbnail_image_url]), counter: -1) %></div>
+              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:thumbnail_image_url], alt: document["spotlight_hidden_title_tesim"]), counter: -1) %></div>
             <% elsif ((block_options[:iiif_tilesource_base].present?) && (block_options[:iiif_tilesource_base] != "undefined"))  %>
               <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!400,400/0/default.jpg'), counter: -1) %></div>
             <% elsif has_thumbnail? document %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
@@ -9,7 +9,7 @@
       <% doc_presenter = index_presenter(document) %>
       <div class="item <%= 'active' if index == 0 %>" data-id="<%= document.id %>">
         <% if block_options[:full_image_url].present? %>
-          <%= link_to_document(document, image_tag(block_options[:full_image_url]), counter: -1) %>
+          <%= link_to_document(document, image_tag(block_options[:full_image_url], alt: document["spotlight_hidden_title_tesim"]), counter: -1) %>
         <% elsif ((block_options[:iiif_tilesource_base].present?) && (block_options[:iiif_tilesource_base] != "undefined"))   %>
           <%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!800,800/0/default.jpg'), counter: -1) %>
         <% elsif has_thumbnail? document %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
@@ -11,7 +11,7 @@
         <% if block_options[:full_image_url].present? %>
           <%= link_to_document(document, image_tag(block_options[:full_image_url], alt: document["spotlight_hidden_title_tesim"]), counter: -1) %>
         <% elsif ((block_options[:iiif_tilesource_base].present?) && (block_options[:iiif_tilesource_base] != "undefined"))   %>
-          <%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!800,800/0/default.jpg'), counter: -1) %>
+          <%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!800,800/0/default.jpg', alt: document["spotlight_hidden_title_tesim"]), counter: -1) %>
         <% elsif has_thumbnail? document %>
           <%= render_thumbnail_tag(document, {}, document_counter: -1) %>
         <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb
@@ -11,7 +11,7 @@
             <% doc_presenter = index_presenter(document) %>
             <div class="item <%= 'active' if index == 0 %>" data-id="<%= document.id %>">
               <% if block_options[:full_image_url].present? %>
-                <%= link_to_document(document, image_tag(block_options[:full_image_url]), counter: -1) %>
+                <%= link_to_document(document, image_tag(block_options[:full_image_url], alt: document["spotlight_hidden_title_tesim"]), counter: -1) %>
               <% elsif ((block_options[:iiif_tilesource_base].present?) && (block_options[:iiif_tilesource_base] != "undefined"))  %>
                 <%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!800,800/0/default.jpg'), counter: -1) %>
               <% elsif has_thumbnail? document %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb
@@ -13,7 +13,7 @@
               <% if block_options[:full_image_url].present? %>
                 <%= link_to_document(document, image_tag(block_options[:full_image_url], alt: document["spotlight_hidden_title_tesim"]), counter: -1) %>
               <% elsif ((block_options[:iiif_tilesource_base].present?) && (block_options[:iiif_tilesource_base] != "undefined"))  %>
-                <%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!800,800/0/default.jpg'), counter: -1) %>
+                <%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!800,800/0/default.jpg', alt: document["spotlight_hidden_title_tesim"]), counter: -1) %>
               <% elsif has_thumbnail? document %>
                 <%= render_thumbnail_tag(document, {}, document_counter: -1) %>
               <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
@@ -7,7 +7,7 @@
             <% if block_options[:thumbnail_image_url].present? %>
               <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:thumbnail_image_url], alt: document["spotlight_hidden_title_tesim"]), counter: -1) %></div>
             <% elsif ((block_options[:iiif_tilesource_base].present?) && (block_options[:iiif_tilesource_base] != "undefined"))  %>
-              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!400,400/0/default.jpg'), counter: -1) %></div>
+              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!400,400/0/default.jpg', alt: document["spotlight_hidden_title_tesim"]), counter: -1) %></div>
             <% elsif has_thumbnail? document %>
               <div class="thumbnail"><%= render_thumbnail_tag(document, {}, document_counter: -1) %></div>
             <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
@@ -5,7 +5,7 @@
         <% solr_documents_grid_block.each_document.each_with_index do |(block_options, document), index| %>
           <div class="box item-<%= index %>" data-id="<%= document.id %>">
             <% if block_options[:thumbnail_image_url].present? %>
-              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:thumbnail_image_url]), counter: -1) %></div>
+              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:thumbnail_image_url], alt: document["spotlight_hidden_title_tesim"]), counter: -1) %></div>
             <% elsif ((block_options[:iiif_tilesource_base].present?) && (block_options[:iiif_tilesource_base] != "undefined"))  %>
               <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!400,400/0/default.jpg'), counter: -1) %></div>
             <% elsif has_thumbnail? document %>


### PR DESCRIPTION
see #59, this changes the gallery-type widgets that display exhibit items. Because the displayed images are links to the items' show pages, the alt text will be set to the title of the item.