### PR TITLE
Change ids

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,8 @@
 module ApplicationHelper
 
-  def od_link(in_hash)
-    if in_hash[:value].first.include? "oregondigital"
-      link_to "https://oregondigital.org/catalog/#{in_hash[:value].first}", "#{ENV['OD_URL']}/catalog/#{in_hash[:value].first}"
-    else
-      nil
-    end
+  #The link_to will need to be redone when OD2 goes live
+  #Use the solr document to get at the model for creating the uri
+  def od_link(args)
+    link_to "https://oregondigital.org/catalog/#{args[:document][args[:field]].first}", "#{ENV['OD_URL']}/catalog/#{args[:document][args[:field]].first}"
   end
 end

--- a/app/services/oregon_digital/solr_document_builder.rb
+++ b/app/services/oregon_digital/solr_document_builder.rb
@@ -23,12 +23,13 @@ module OregonDigital
     end
 
     def out_doc_init
-      { id: in_doc['id'],
+      { id: in_doc['id'].gsub('oregondigital:', ''),
         Spotlight::Engine.config.thumbnail_field => get_thumb,
         Spotlight::Engine.config.full_image_field => ENV['OD_URL'] + "/downloads/#{in_doc['id']}.jpg",
         oembed_url_ssm: "#{ENV['OD_URL']}/resource/#{in_doc['id']}",
         pid_ssm: in_doc['id'],
-        spotlight_hidden_title_tesim: in_doc["desc_metadata__title_tesim"]
+        spotlight_hidden_title_tesim: in_doc["desc_metadata__title_tesim"],
+        model_ssi: in_doc['active_fedora_model_ssi']
       }
     end
 


### PR DESCRIPTION
modifies the oregondigital solr document builder so that new resources are saved with only the unique part of the OD1 pid. Required before upgrading Blacklight.