### PR TITLE
max-height thumb

### DIFF
--- a/app/assets/stylesheets/demo.scss
+++ b/app/assets/stylesheets/demo.scss
@@ -36,3 +36,7 @@ body {
   white-space: nowrap;
   display: inline-flex;
 }
+
+.thumbnail a > img, .thumbnail > img{
+  max-height: 300px !important;
+}


### PR DESCRIPTION
limit thumb height with css. the images coming from OD via iiif are not scaled at all in this version of spotlight, but will be after upgrade.