### PR TITLE
Title configs alpine

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -42,21 +42,21 @@ class CatalogController < ApplicationController
     config.document_unique_id_param = 'ids'
 
     # solr field configuration for search results/index views
-    config.index.title_field = ::Blacklight::Configuration::Field.new(field:'full_title_tesim', accessor: :title)
+    #title
+    config.index.title_field = 'full_title_tesim'
+    config.index.display_title_field = 'full_title_tesim'
 
     config.add_search_field 'all_fields', label: 'Everything'
 
     config.add_sort_field 'relevance', sort: 'score desc', label: 'Relevance'
-    config.add_index_field 'desc_metadata__set_label_ssim', label: 'Set'
     config.add_field_configuration_to_solr_request!
 
-    #FIX ANGLE BRACKETS ON LOCATIONS
-    #config.add_facet_field 'readonly_location_tesim', label: 'Region', limit: true, helper_method: :od_label
+    config.add_facet_field 'readonly_location_tesim', label: 'Region', limit: true
+    config.add_facet_field 'readonly_subject_tesim', label: 'Topics', limit: true
     config.add_facet_fields_to_solr_request!
 
-
-    config.show.title_field = ::Blacklight::Configuration::Field.new(field:'full_title_tesim', accessor: :title)
-    config.add_show_field 'pid_ssm', label: 'See it at Oregon Digital', helper_method: :od_link
+    # copying dpul here, not wrapping it like this breaks the typeahead in the widgets.
+    config.show.title_field = FieldStringifier.new(::Blacklight::Configuration::Field.new(field:'full_title_tesim', accessor: :title))
 
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)

--- a/app/decorators/field_stringifier.rb
+++ b/app/decorators/field_stringifier.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Another dpul tidbit
+# Spotlight assumes that the title field is the field name, but we need it to be
+# a Field object so it can fall back to override title. This makes it delegate
+# to_s to the field so that autocomplete works.
+class FieldStringifier < SimpleDelegator
+  def to_s
+    __getobj__.field.to_s
+  end
+end
+

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -23,11 +23,12 @@ class SolrDocument
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
 
+  # this is referenced in the catalog_controller
   def title
     if self['readonly_title_tesim'].present?
-      return self['readonly_title_tesim'].first
+      return self['readonly_title_tesim']
     elsif self['spotlight_upload_title_tesim'].present?
-      return self['spotlight_upload_title_tesim'].first
+      return self['spotlight_upload_title_tesim']
     end
     return self['id']
   end

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -204,12 +204,6 @@
 
   <copyField source="id" dest="id_ng" maxChars="3000"/>
 
-
-
-  <!--for uploaded assets -->
-  <copyField source="spotlight_upload_title_tesim" dest="full_title_ng" maxChars="3000"/>
-  <copyField source="spotlight_upload_title_tesim" dest="full_title_tesim" maxChars="3000"/>
-
   <copyField source="full_title_tesim" dest="full_title_ng" maxChars="3000"/>
 
   <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/>

--- a/spec/views/spotlight/catalog/_index_compact_default_spec.rb
+++ b/spec/views/spotlight/catalog/_index_compact_default_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 # unclear why at present but rails couldn't find the admin thumbnail template
 RSpec.describe "spotlight/catalog/_index_compact_default", type: :view do
   let(:exhibit) { FactoryBot.create(:exhibit) }
-  let(:document) { SolrDocument.new(id: 'abcde1234', full_title_tesim: 'Red', thumbnail_url_ssm: ['http://iiif.blah.org/iiif/red-img.png']) }
+  let(:document) { SolrDocument.new(id: 'abcde1234', readonly_title_tesim: 'Red', thumbnail_url_ssm: ['http://iiif.blah.org/iiif/red-img.png']) }
   let(:blacklight_config) { CatalogController.blacklight_config }
   
   before do
@@ -22,6 +22,10 @@ RSpec.describe "spotlight/catalog/_index_compact_default", type: :view do
   it "includes thumbnails" do
     render(partial: "spotlight/catalog/index_compact_default", locals: { document: document, document_counter: 0 })
     expect(rendered).to have_selector(".spotlight-admin-thumbnail")
+  end
+  it 'uses the correct title' do
+    render(partial: "spotlight/catalog/index_compact_default", locals: { document: document, document_counter: 0 })
+    expect(rendered).to have_selector(".index_title:nth-child(1)", text: 'Red')
   end
 end
 


### PR DESCRIPTION
changes default behavior wrt the title that is displayed on a resource show page and in lists; instead of using the resource id, displays the title from the resource's metadata.