### PR TITLE
fix_location_labels

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -51,8 +51,8 @@ class CatalogController < ApplicationController
     config.add_sort_field 'relevance', sort: 'score desc', label: 'Relevance'
     config.add_field_configuration_to_solr_request!
 
-    config.add_facet_field 'readonly_location_tesim', label: 'Region', limit: true
-    config.add_facet_field 'readonly_subject_tesim', label: 'Topics', limit: true
+    config.add_facet_field 'readonly_location_ssim', label: 'Region', limit: true
+    config.add_facet_field 'readonly_subject_ssim', label: 'Topics', limit: true
     config.add_facet_fields_to_solr_request!
 
     # copying dpul here, not wrapping it like this breaks the typeahead in the widgets.

--- a/app/decorators/both_fields.rb
+++ b/app/decorators/both_fields.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Want both tesim and ssim on readonly fields on incoming iiif resources
+# more shameless copying from dpul
+class BothFields < SimpleDelegator
+  def alternate_field
+    field.gsub(/(.*)_.*$/, '\1' + alternate_field_suffix)
+  end
+
+  private
+
+    def alternate_field_suffix
+      if field.ends_with?(Spotlight::Engine.config.solr_fields.string_suffix)
+        Spotlight::Engine.config.solr_fields.text_suffix
+      else
+        Spotlight::Engine.config.solr_fields.string_suffix
+      end
+    end
+end
+
+

--- a/app/models/concerns/iiif_manifest_behavior.rb
+++ b/app/models/concerns/iiif_manifest_behavior.rb
@@ -1,0 +1,23 @@
+module IiifManifestBehavior
+  extend ActiveSupport::Concern
+  # Copying dpul BothFields fix
+  def manifest_metadata
+
+    @manifest_metadata ||=
+      begin
+        metadata = metadata_class.new(manifest).to_solr
+        return {} if metadata.blank?
+
+        create_sidecars_for(*metadata.keys)
+
+        metadata.each_with_object({}) do |(key, value), hash|
+          next unless (field = exhibit_custom_fields[key])
+
+          field = BothFields.new(field)
+          hash[field.field] = value
+          hash[field.alternate_field] = value
+        end
+      end
+  end
+end
+

--- a/app/models/iiif_metadata.rb
+++ b/app/models/iiif_metadata.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+###
+#  A simple class to map the metadata field
+#  in a IIIF document to label/value pairs
+#  This is intended to be overriden by an
+#  application if a different metadata
+#  strucure is used by the consumer
+class IiifMetadata < Spotlight::Resources::IiifManifest::Metadata
+
+  def html_sanitize(value)
+    return value if oregondigital?
+
+    super
+  end
+
+  def oregondigital?
+    URI(@manifest['@id']).host.include? 'oregondigital.org'
+  end
+end
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,7 @@ module SpotlightDemo
     config.to_prepare do
       Spotlight::Resources::UploadController.prepend(UploadControllerBehavior)
       Spotlight::FeaturedImageUploader.prepend(CarrierWaveOption)
+      Spotlight::Resources::IiifManifest.prepend(IiifManifestBehavior)
     end
   end
 end

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -53,6 +53,7 @@ Spotlight::Engine.config.upload_title_field = Spotlight::UploadFieldConfig.new(
 )
 
 Spotlight::Engine.config.iiif_title_fields = 'full_title_tesim'
+Spotlight::Engine.config.iiif_metadata_class = -> { IiifMetadata }
 
 # Spotlight::Engine.config.uploader_storage = :file
 # Spotlight::Engine.config.allowed_upload_extensions = %w(jpg jpeg png)

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -86,6 +86,8 @@
        <str name="facet.field">active_fedora_model_ssi</str>
        <str name="facet.field">subject_ssim</str>
        <str name="facet.field">desc_metadata__location_ssim</str>
+       <str name="facet.field">readonly_subject_ssim</str>
+       <str name="facet.field">readonly_location_ssim</str>
        
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>

--- a/spec/decorators/both_fields_spec.rb
+++ b/spec/decorators/both_fields_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BothFields do
+  subject(:decorator) { described_class.new(field) }
+  let(:field) { instance_double(Spotlight::CustomField, field: field_name) }
+  describe "#alternate_field" do
+    context "when given a tesim field" do
+      let(:field_name) { "test_tesim" }
+      it "returns _ssim" do
+        expect(decorator.alternate_field).to eq "test_ssim"
+      end
+    end
+
+    context "when given a ssim field" do
+      let(:field_name) { "test_ssim" }
+      it "returns _tesim" do
+        expect(decorator.alternate_field).to eq "test_tesim"
+      end
+    end
+  end
+end
+
+

--- a/spec/fixtures/iiif_responses.rb
+++ b/spec/fixtures/iiif_responses.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module IiifResponses
+
+  def test_manifest1
+    {
+      "@id": 'https://oregondigital.org/iiif_manifest_v2/abcde1234',
+      "@type": 'sc:Manifest',
+      label: 'Test Manifest 1',
+      attribution: 'Attribution Data',
+      description: 'A test IIIF manifest',
+      license: 'http://www.example.org/license.html',
+      metadata: [
+        {
+          label: 'Author',
+          value: 'Kilgore Trout'
+        },
+        {
+          label: 'Location',
+          value: ["Portland >> Clackamas/Multnomah/Washington Counties >> Oregon >> United States"]
+        }
+      ],
+      thumbnail: {
+        "@id": 'uri://to-thumbnail'
+      },
+      sequences: [
+        {
+          "@type": 'sc:Sequence',
+          canvases: [
+            {
+              "@type": 'sc:Canvas',
+              images: [
+                {
+                  "@type": 'oa:Annotation',
+                  resource: {
+                    "@type": 'dcterms:Image',
+                    "@id": 'uri://full-image',
+                    service: {
+                      "@id": 'uri://to-image-service'
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }.to_json
+  end
+end
+

--- a/spec/models/spotlight/resources/iiif_manifest_spec.rb
+++ b/spec/models/spotlight/resources/iiif_manifest_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Spotlight::Resources::IiifManifest do
+  let(:url) { 'https://oregondigital.org/iiif_manifest_v2/abcde1234' }
+  subject { described_class.new(url: url, manifest: manifest, collection: collection) }
+  let(:collection) { double(compound_id: '1') }
+  let(:manifest_fixture) { test_manifest1 }
+  let(:location_label) { "Portland >> Clackamas/Multnomah/Washington Counties >> Oregon >> United States" }
+  before do
+    stub_iiif_response_for_url(url, manifest_fixture)
+    subject.with_exhibit(exhibit)
+  end
+
+  describe '#to_solr' do
+    let(:manifest) { Spotlight::Resources::IiifService.new(url).send(:object) }
+    let(:exhibit) { FactoryBot.create(:exhibit) }
+
+    describe 'metadata' do
+      context 'custom class' do
+        before do
+          allow(Spotlight::Engine.config).to receive(:iiif_metadata_class).and_return(-> { IiifMetadata })
+        end
+
+        it 'does not use html_sanitize on all the things' do
+          expect(subject.to_solr['readonly_location_tesim']).to eq [location_label]
+        end
+      end
+    end
+  end
+end
+
+

--- a/spec/support/stub_iiif_response.rb
+++ b/spec/support/stub_iiif_response.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'fixtures/iiif_responses'
+module StubIiifResponse
+  def stub_iiif_response_for_url(url, response)
+    allow(Spotlight::Resources::IiifService).to receive(:iiif_response).with(url).and_return(response)
+  end
+end
+RSpec.configure do |config|
+  config.include IiifResponses
+  config.include StubIiifResponse
+end
+
+


### PR DESCRIPTION
Currently, spotlight sanitizes metadata prior to building the solr document; this creates the problem that html-safe replacements for characters such as angle brackets are getting indexed, eg "&amp;gt;" or "&amp;lt;"
This fix prevents sanitizing if the metadata is coming from OD.
Additionally, this indexes iiif subjects and locations as strings (as opposed to tokens) so that they may be used as facets.